### PR TITLE
Bugfix: Data export downloading from Microsoft Edge working

### DIFF
--- a/src/helper_download.js
+++ b/src/helper_download.js
@@ -7,7 +7,7 @@ Encapulates some browser-specific API differences.
 @returns {undefined}
 */
 function downloadData(filename, data) {
-    if (navigator.appName === "Microsoft Internet Explorer") {
+    if (typeof(window.navigator.msSaveBlob) === "function") {
         var blob = new Blob([data], {
             type: "text/plain"
         });


### PR DESCRIPTION
Microsoft Edge is now identified by `typeof(window.navigator.msSaveBlob)
=== "function"`.
This function is actually used for exporting data.