### PR TITLE
package.json: corrected license identifier (SPDX complaince).

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "TheFragebogen",
-    "license": "MIT License",
+    "license": "MIT",
     "repository": "https://github.com/TheFragebogen/TheFragebogen",
     "homepage": "http://thefragebogen.de",
     "devDependencies": {


### PR DESCRIPTION
Removes warning on `npm install`:

`npm WARN TheFragebogen@ license should be a valid SPDX license expression`.
