### PR TITLE
Added: Video/Audio statistics, replaying and corresponding examples

### DIFF
--- a/src/questionnaireitem_media.js
+++ b/src/questionnaireitem_media.js
@@ -114,6 +114,7 @@ QuestionnaireItemMedia.prototype._onloaded = function() {
 
 QuestionnaireItemMedia.prototype._onstalled = function() {
     this.stallingCount += 1;
+    this._updateAnswer();
     this._sendOnPreloadedCallback();
 
     TheFragebogen.logger.warn(this.constructor.name + "._onstalled()", "Stalling occured (" + this.stallingCount + ") for " + this.getURL());
@@ -121,6 +122,7 @@ QuestionnaireItemMedia.prototype._onstalled = function() {
 
 QuestionnaireItemMedia.prototype._onerror = function() {
     this.stallingCount += 1;
+    this._updateAnswer();
     this._sendOnPreloadedCallback();
 
     TheFragebogen.logger.error(this.constructor.name + "._onerror()", "Stalling occured (" + this.stallingCount + ") for " + this.getURL());
@@ -154,4 +156,8 @@ QuestionnaireItemMedia.prototype._checkData = function(data) {
 
 QuestionnaireItemMedia.prototype.setData = function(data) {
     return this._checkData(data);
+};
+
+QuestionnaireItemMedia.prototype._updateAnswer = function() {
+    TheFragebogen.logger.debug(this.constructor.name + "._updateAnswer()", "This method must be overridden if progress reporting is desired.");
 };

--- a/src/questionnaireitem_media_audio.js
+++ b/src/questionnaireitem_media_audio.js
@@ -1,6 +1,13 @@
 /**
 A QuestionnaireItemMedia that plays an audio file.
 NOTE: Useful to capture failure to loads.
+This item reports as an array audio playback statistics [url, duration, stallingCount, replayCount, audioStartTimes, audioPlayDurations].
+url corresponds to the array of all sources for this element.
+The duration is the total audio length in seconds.
+stallingCount counts how often a stalling event occured.
+replayCount counts how often the audio got replayed explicitly by the user.
+audioStartTimes are the points in time, relative to creation of the audio, when the audio started playing.
+audioPlayDurations are the times in seconds how long the audio played each time.
 
 @class QuestionnaireItemMediaAudio
 @augments UIElement
@@ -22,6 +29,11 @@ function QuestionnaireItemMediaAudio(className, question, required, url, readyOn
 
     this.audioNode = null;
     this.progressbar = null;
+
+    this.audioPlayDurations = []; // Stores how long the audio got listend to each time
+    this.audioCreationTime = null; // Point in time when the audio gets created
+    this.audioStartTimes = []; // Stores when the audio started relative to audioCreationTime
+    this.replayCount = 0; // Counts how often the audio got replayed explicitly with replay()
 }
 QuestionnaireItemMediaAudio.prototype = Object.create(QuestionnaireItemMedia.prototype);
 QuestionnaireItemMediaAudio.prototype.constructor = QuestionnaireItemMediaAudio;
@@ -39,7 +51,10 @@ QuestionnaireItemMediaAudio.prototype._createAnswerNode = function() {
     this.audioNode.ontimeupdate = this._onprogress.bind(this);
     this.audioNode.onerror = this._onerror.bind(this);
     this.audioNode.onended = this._onended.bind(this);
+    this.audioNode.onstalled = this._onstalled.bind(this);
+    this.audioNode.onplay = this._onplay.bind(this);
 
+    this.audioCreationTime = new Date().getTime();
     return node;
 };
 
@@ -47,6 +62,9 @@ QuestionnaireItemMediaAudio.prototype.releaseUI = function() {
     this.node = null;
     this.uiCreated = false;
     this.enabled = false;
+
+    this.audioPlayDurations.push(this.audioNode.currentTime);
+    this._updateAnswer();
 
     this.audioNode = null;
     this.progressbar = null;
@@ -77,6 +95,16 @@ QuestionnaireItemMediaAudio.prototype._createMediaNode = function() {
     this.audioNode.appendChild(pTag);
 };
 
+QuestionnaireItemMediaAudio.prototype.replay = function() {
+    this.audioPlayDurations.push(this.audioNode.currentTime);
+    this.replayCount += 1;
+    this._updateAnswer();
+
+    this.audioNode.pause();
+    this.audioNode.currentTime = 0.0;
+    this.audioNode.play();
+};
+
 QuestionnaireItemMediaAudio.prototype._play = function() {
     if (this.audioNode === null) {
         TheFragebogen.logger.warn(this.constructor.name + "()", "Cannot start playback without this.audioNode.");
@@ -102,4 +130,13 @@ QuestionnaireItemMediaAudio.prototype._onprogress = function() {
     if (this.progressbar && !isNaN(this.audioNode.duration)) {
         this.progressbar.value = (this.audioNode.currentTime / this.audioNode.duration);
     }
+};
+
+QuestionnaireItemMediaAudio.prototype._onplay = function() {
+    this.audioStartTimes.push((new Date().getTime() - this.audioCreationTime) / 1000);
+    this._updateAnswer();
+};
+
+QuestionnaireItemMediaAudio.prototype._updateAnswer = function() {
+    this.answer = [this.url, this.audioNode.duration, this.stallingCount, this.replayCount, this.audioStartTimes, this.audioPlayDurations];
 };

--- a/src/questionnaireitem_media_video.js
+++ b/src/questionnaireitem_media_video.js
@@ -1,6 +1,13 @@
 /**
 A QuestionnaireItemMedia that plays a video.
 NOTE: Useful to capture failure to loads.
+This item reports as an array video playback statistics [url, duration, stallingCount, replayCount, videoStartTimes, videoPlayDurations].
+url corresponds to the array of all sources for this element.
+The duration is the total video length in seconds.
+stallingCount counts how often a stalling event occured.
+replayCount counts how often the video got replayed explicitly by the user.
+videoStartTimes are the points in time, relative to creation of the video, when the video started playing.
+videoPlayDurations are the times in seconds how long the audio played each time.
 
 @class QuestionnaireItemMediaVideo
 @augments UIElement
@@ -21,6 +28,11 @@ function QuestionnaireItemMediaVideo(className, question, required, url, readyOn
     TheFragebogen.logger.debug(this.constructor.name + "()", "Set: className as " + this.className + ", urls as " + this.height + ", width as " + this.width);
 
     this.videoNode = null;
+
+    this.videoPlayDurations = []; // Stores how long the video got watched each time
+    this.videoCreationTime = null; // Point in time when the video gets created
+    this.videoStartTimes = []; // Stores when the video started relative to videoCreationTime
+    this.replayCount = 0; // Counts how often the video got replayed explicitly with replay()
 }
 QuestionnaireItemMediaVideo.prototype = Object.create(QuestionnaireItemMedia.prototype);
 QuestionnaireItemMediaVideo.prototype.constructor = QuestionnaireItemMediaVideo;
@@ -35,7 +47,10 @@ QuestionnaireItemMediaVideo.prototype._createAnswerNode = function() {
     this.videoNode.ontimeupdate = this._onprogress.bind(this);
     this.videoNode.onerror = this._onerror.bind(this);
     this.videoNode.onended = this._onended.bind(this);
+    this.videoNode.onstalled = this._onstalled.bind(this);
+    this.videoNode.onplay = this._onplay.bind(this);
 
+    this.videoCreationTime = new Date().getTime();
     return node;
 };
 
@@ -43,6 +58,9 @@ QuestionnaireItemMediaVideo.prototype.releaseUI = function() {
     this.node = null;
     this.uiCreated = false;
     this.enabled = false;
+
+    this.videoPlayDurations.push(this.videoNode.currentTime);
+    this._updateAnswer();
 
     this.videoNode = null;
 };
@@ -73,6 +91,16 @@ QuestionnaireItemMediaVideo.prototype._createMediaNode = function() {
     this.videoNode.appendChild(pTag);
 };
 
+QuestionnaireItemMediaVideo.prototype.replay = function() {
+    this.videoPlayDurations.push(this.videoNode.currentTime);
+    this.replayCount += 1;
+    this._updateAnswer();
+
+    this.videoNode.pause();
+    this.videoNode.currentTime = 0.0;
+    this.videoNode.play();
+};
+
 QuestionnaireItemMediaVideo.prototype._play = function() {
     if (this.videoNode === null) {
         TheFragebogen.logger.warn(this.constructor.name + "()", "Cannot start playback without this.videoNode.");
@@ -97,4 +125,13 @@ QuestionnaireItemMediaVideo.prototype._pause = function() {
 
 QuestionnaireItemMediaVideo.prototype._onprogress = function() {
     //Nope
+};
+
+QuestionnaireItemMediaVideo.prototype._onplay = function() {
+    this.videoStartTimes.push((new Date().getTime() - this.videoCreationTime) / 1000);
+    this._updateAnswer();
+};
+
+QuestionnaireItemMediaVideo.prototype._updateAnswer = function() {
+    this.answer = [this.url, this.videoNode.duration, this.stallingCount, this.replayCount, this.videoStartTimes, this.videoPlayDurations];
 };


### PR DESCRIPTION
Implemented replaying for videos. Exemplary implementation for video statistics:
- how often did a video get replayed
- how long was each replay
- when did the video start relative to visiting the site
- how often was the video played till the end