### PR TITLE
QuestionnaireItemDefinedSelector: bug circumventing mandatory questions

### DIFF
--- a/src/questionnaireitem_defined_selector.js
+++ b/src/questionnaireitem_defined_selector.js
@@ -45,7 +45,8 @@ QuestionnaireItemDefinedSelector.prototype._createAnswerNode = function() {
     return node;
 };
 QuestionnaireItemDefinedSelector.prototype._handleChange = function(event) {
-    this.answer = this.select.value;
+    // It is possible to select the optionNull field again to circumvent mandatory questions.
+    this.answer = this.select.value === "" ? null : this.select.value;
     this._sendReadyStateChanged();
 };
 


### PR DESCRIPTION
It is possible to circumvent mandatory questions in the QuestionnaireItemDefinedSelector class. First, select one item. Second, select the empty element in the list again. Then it is possible to continue to the next page without the need to provide an answer to that question.