### PR TITLE
Added: Multiple sources for video/audio/images

### DIFF
--- a/src/questionnaireitem_media.js
+++ b/src/questionnaireitem_media.js
@@ -13,13 +13,14 @@ Playable media start playing automatically if loaded (canplaythrough=true) and `
 @param {string} [question]
 @param {boolean} [required=false]
 @param {string} url The URL of the media element to be loaded; if supported by the browser also data URI.
+@param {string|array} url The URL of the media element to be loaded; if supported by the browser also data URI. A single resource can be provided as string or multiple resources of different formats as an array.
 @param {boolean} required Element must report ready before continue.
 @param {boolean} [readyOnError] Set `ready=true` if an error occures.
 */
 function QuestionnaireItemMedia(className, question, required, url, readyOnError) {
     QuestionnaireItem.call(this, className, question, required);
 
-    this.url = url;
+    this.url = Array.isArray(url) ? url : [url];
     this.isContentLoaded = false;
     this.stallingCount = 0;
     this.wasSuccessfullyPlayed = false;

--- a/src/questionnaireitem_media_audio.js
+++ b/src/questionnaireitem_media_audio.js
@@ -65,6 +65,12 @@ QuestionnaireItemMediaAudio.prototype._createMediaNode = function() {
     this.audioNode = new Audio();
     this.audioNode.oncanplaythrough = this._onloaded.bind(this);
     this.audioNode.src = this.url;
+
+    for (var i = 0; i < this.url.length; i++) {
+        audioSource = document.createElement("source");
+        audioSource.src = this.url[i];
+        this.audioNode.appendChild(audioSource);
+    }
 };
 
 QuestionnaireItemMediaAudio.prototype._play = function() {

--- a/src/questionnaireitem_media_image.js
+++ b/src/questionnaireitem_media_image.js
@@ -20,6 +20,10 @@ function QuestionnaireItemMediaImage(className, question, required, url, readyOn
 
     TheFragebogen.logger.debug("QuestionnaireItemMediaImage()", "Set: className as " + this.className + ", height as " + this.height + ", width as " + this.width);
 
+    if (this.url.length != 1) {
+        TheFragebogen.logger.warn("QuestionnaireItemMediaImage()", "called with multiple resources as url. Falling back to the first element in the array.");
+    }
+
     this.imageNode = null;
 }
 QuestionnaireItemMediaImage.prototype = Object.create(QuestionnaireItemMedia.prototype);
@@ -55,5 +59,5 @@ QuestionnaireItemMediaImage.prototype._createMediaNode = function() {
 
     this.imageNode = new Image();
     this.imageNode.onload = this._onloaded.bind(this);
-    this.imageNode.src = this.url;
+    this.imageNode.src = this.url[0];
 };

--- a/src/questionnaireitem_media_video.js
+++ b/src/questionnaireitem_media_video.js
@@ -59,7 +59,12 @@ QuestionnaireItemMediaVideo.prototype._createMediaNode = function() {
 
     this.videoNode = document.createElement('video');
     this.videoNode.oncanplaythrough = this._onloaded.bind(this);
-    this.videoNode.src = this.url;
+
+    for (var i = 0; i < this.url.length; i++) {
+        videoSource = document.createElement("source");
+        videoSource.src = this.url[i];
+        this.videoNode.appendChild(videoSource);
+    }
 };
 
 QuestionnaireItemMediaVideo.prototype._play = function() {


### PR DESCRIPTION
Allows specifying multiple sources for video and audio. The browser then chooses the format it supports. For images, only a single resource is supported. A warning is displayed, if not exactly one image resource is provided.