### PR TITLE
Audio/Video: removed src attribute

### DIFF
--- a/src/questionnaireitem_media_audio.js
+++ b/src/questionnaireitem_media_audio.js
@@ -64,7 +64,6 @@ QuestionnaireItemMediaAudio.prototype._createMediaNode = function() {
 
     this.audioNode = new Audio();
     this.audioNode.oncanplaythrough = this._onloaded.bind(this);
-    this.audioNode.src = this.url;
 
     for (var i = 0; i < this.url.length; i++) {
         var audioSource = document.createElement("source");

--- a/src/questionnaireitem_media_video.js
+++ b/src/questionnaireitem_media_video.js
@@ -66,8 +66,6 @@ QuestionnaireItemMediaVideo.prototype._createMediaNode = function() {
         this.videoNode.appendChild(videoSource);
     }
 
-    this.videoNode.src = this.url;
-
     pTag = document.createElement("p");
     pTag.innerHTML = "This is a fallback content. Your browser does not support the provided video formats.";
     this.videoNode.appendChild(pTag);


### PR DESCRIPTION
### Type of change
<!--- Put an `x` in all the boxes that apply: -->
* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Maintenance (eg., documentation, code cleanup)

## General information
<!--- Please fill out the table: -->
|Developed and tested on:                                         | |
|--------------------------------|--------------------------------|
|Web browser incl. exact version |Chromium: 74.0.3729.131 (Official Build) |
|Operating system                |Arch Linux (64-Bit)|

<!--- Is the change specific for a platform or web browser? -->
* [x] Web browser/platform specific
  If yes: ...

## What does the changes do?

Remove the `src` attribute from the `<video>` and `<audio>` nodes. PR #45 added the `<source>` tag allowing for multiple sources. Since then, `src` is not required anymore.

## (optional) What is the benefit?

...

## Final checks

* [x] Commit messages are explanatory  
  (for examples see [commits](https://github.com/TheFragebogen/TheFragebogen/commits/master))
* [x] Code follows [CODING.md](CODING.md)
* [x] (optional) executed `grunt format; grunt lint; grunt test`

## License
By submitting a pull request, I understand that the code is provided under [MIT License](LICENSE.md).
