### PR TITLE
Documentation: Typos in QuestionnaireItemMediaVideo fixed

### DIFF
--- a/src/questionnaireitem_media_video.js
+++ b/src/questionnaireitem_media_video.js
@@ -7,7 +7,7 @@ The duration is the total video length in seconds.
 stallingCount counts how often a stalling event occured.
 replayCount counts how often the video got replayed explicitly by the user.
 videoStartTimes are the points in time, relative to creation of the video, when the video started playing.
-videoPlayDurations are the times in seconds how long the audio played each time.
+videoPlayDurations are the times in seconds how long the video played each time.
 
 @class QuestionnaireItemMediaVideo
 @augments UIElement
@@ -68,7 +68,7 @@ class QuestionnaireItemMediaVideo extends QuestionnaireItemMedia {
 
     _createMediaNode() {
         if (this.videoNode !== null) {
-            TheFragebogen.logger.debug(this.constructor.name + "()", "audioNode was already created.");
+            TheFragebogen.logger.debug(this.constructor.name + "()", "videoNode was already created.");
             return;
         }
 


### PR DESCRIPTION
### Type of change
<!--- Put an `x` in all the boxes that apply: -->
* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [x] Maintenance (eg., documentation, code cleanup)

## General information
<!--- Please fill out the table: -->
|Developed and tested on:                                         ||
|--------------------------------|--------------------------------|
|Web browser incl. exact version |Chromium: 74.0.3729.131 (Official Build)|
|Operating system                |Arch Linux (64-Bit)|

<!--- Is the change specific for a platform or web browser? -->
* [ ] Web browser/platform specific
  If yes: ...

## What does the changes do?

Changed documentation of QuestionnaireItemMediaVideo. There were two places with _audio_ instead of  _video_.

## (optional) What is the benefit?

...

## Final checks

* [x] Commit messages are explanatory  
  (for examples see [commits](https://github.com/TheFragebogen/TheFragebogen/commits/master))
* [x] Code follows [CODING.md](CODING.md)
* [x] (optional) executed `grunt format; grunt lint; grunt test`

## License
By submitting a pull request, I understand that the code is provided under [MIT License](LICENSE.md).
