### PR TITLE
QuestionnaireItemSystemFocus/ViewportSize: Bugfix syntax constructor

### DIFF
--- a/src/questionnaireitem_system_focus.js
+++ b/src/questionnaireitem_system_focus.js
@@ -15,7 +15,7 @@ All event listeners are attached as non-capturing.
 class QuestionnaireItemSystemFocus extends QuestionnaireItemSystem {
 
     constructor() {
-        QuestionnaireItemSystem.call(this, null, "Focus", false);
+        super(null, "Focus", false);
 
         this.answer = [];
         this.timeOfLastFocusEvent = null;

--- a/src/questionnaireitem_system_viewport_size.js
+++ b/src/questionnaireitem_system_viewport_size.js
@@ -13,7 +13,7 @@ It gets measured at the time of createUI().
 class QuestionnaireItemSystemViewportSize extends QuestionnaireItemSystem {
 
     constructor() {
-        QuestionnaireItemSystem.call(this, null, "Viewport size", false);
+        super(null, "Viewport size", false);
     }
 
     createUI() {


### PR DESCRIPTION
### Type of change
<!--- Put an `x` in all the boxes that apply: -->
* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Maintenance (eg., documentation, code cleanup)

## General information
<!--- Please fill out the table: -->
|Developed and tested on:                                         ||
|--------------------------------|--------------------------------|
|Web browser incl. exact version |Chromium: 74.0.3729.131 (Official Build)|
|Operating system                |Arch Linux (64-Bit)|

<!--- Is the change specific for a platform or web browser? -->
* [ ] Web browser/platform specific
  If yes: ...

## What does the changes do?

Call super constructor in `QuestionnaireItemSystemFocus` and `QuestionnaireItemSystemViewportSize` instead of depricated ones.

## (optional) What is the benefit?

...

## Final checks

* [x] Commit messages are explanatory  
  (for examples see [commits](https://github.com/TheFragebogen/TheFragebogen/commits/master))
* [x] Code follows [CODING.md](CODING.md)
* [x] (optional) executed `grunt format; grunt lint; grunt test`

## License
By submitting a pull request, I understand that the code is provided under [MIT License](LICENSE.md).
